### PR TITLE
👌 IMPROVE: Support numref placeholders

### DIFF
--- a/sphinx_exercise/__init__.py
+++ b/sphinx_exercise/__init__.py
@@ -272,13 +272,13 @@ class DoctreeResolve:
         node_title = node.get("title", "")
 
         if "{name}" in node_title and self._has_math_child(source_node[0]):
-
             newtitle = nodes.inline()
             for item in node_title.split():
                 if item == "{name}":
+                    # use extend instead?
                     for _ in self._update_title(source_node[0]):
                         newtitle += _
-                elif item == "{number}" or item == "%s":
+                elif item == "{number}":
                     source_docname = source_attr.get("docname", "")
                     source_type = self.domain.get_enumerable_node_type(source_node)
                     source_number = self.domain.get_fignumber(

--- a/tests/books/test-mybook/exercise/_enum_numref_placeholders.rst
+++ b/tests/books/test-mybook/exercise/_enum_numref_placeholders.rst
@@ -1,0 +1,25 @@
+_enum_numref_placeholders
+=========================
+
+
+This reference does not include math :numref:`some {number} text %s test {name} <test-exc-label>`.
+
+This reference does not include math :numref:`some {number} text %s test <test-exc-label>`.
+
+This reference does not include math :numref:`some {name} text %s test <test-exc-label>`.
+
+This reference does not include math :numref:`some {name} text {number} test <test-exc-label>`.
+
+This reference does not include math :numref:`some %s text test <test-exc-label>`.
+
+
+
+This reference includes math :numref:`some {number} text %s test {name} <test-exc-label-math>`.
+
+This reference includes math :numref:`some {number} text %s test <test-exc-label-math>`.
+
+This reference includes math :numref:`some {name} text %s test <test-exc-label-math>`.
+
+This reference includes math :numref:`some {name} text {number} test <test-exc-label-math>`.
+
+This reference includes math :numref:`some %s text test <test-exc-label-math>`.

--- a/tests/books/test-mybook/index.rst
+++ b/tests/books/test-mybook/index.rst
@@ -26,6 +26,7 @@ A Test Program!
    exercise/_unenum_numref_notitle
    exercise/_unenum_numref_title
    exercise/_unenum_numref_mathtitle
+   exercise/_enum_numref_placeholders
 
    exercise/_enum_duplicate_label
 

--- a/tests/test_exercise.py
+++ b/tests/test_exercise.py
@@ -44,6 +44,7 @@ def test_exercise(app, idir, file_regression):
         "_unenum_numref_mathtitle.html",
         "_unenum_numref_notitle.html",
         "_unenum_numref_title.html",
+        "_enum_numref_placeholders.html",
     ],
 )
 def test_reference(app, idir, file_regression):

--- a/tests/test_exercise/_enum_numref_placeholders.html
+++ b/tests/test_exercise/_enum_numref_placeholders.html
@@ -1,0 +1,10 @@
+<p>This reference does not include math <a class="reference internal" href="_enum_title_class_label.html#test-exc-label"><span class="std std-numref">some 3 text %s test Test exercise directive</span></a>.</p>
+<p>This reference does not include math <a class="reference internal" href="_enum_title_class_label.html#test-exc-label"><span class="std std-numref">some 3 text %s test</span></a>.</p>
+<p>This reference does not include math <a class="reference internal" href="_enum_title_class_label.html#test-exc-label"><span class="std std-numref">some Test exercise directive text %s test</span></a>.</p>
+<p>This reference does not include math <a class="reference internal" href="_enum_title_class_label.html#test-exc-label"><span class="std std-numref">some Test exercise directive text 3 test</span></a>.</p>
+<p>This reference does not include math <a class="reference internal" href="_enum_title_class_label.html#test-exc-label"><span class="std std-numref">some 3 text test</span></a>.</p>
+<p>This reference includes math <a class="reference internal" href="_enum_mathtitle_label.html#test-exc-label-math"><span>some 1 text %s test Test <span class="math notranslate nohighlight">\(\mathbb{R}\)</span></span></a>.</p>
+<p>This reference includes math <a class="reference internal" href="_enum_mathtitle_label.html#test-exc-label-math"><span class="std std-numref">some 1 text %s test</span></a>.</p>
+<p>This reference includes math <a class="reference internal" href="_enum_mathtitle_label.html#test-exc-label-math"><span>some Test <span class="math notranslate nohighlight">\(\mathbb{R}\)</span> text %s test</span></a>.</p>
+<p>This reference includes math <a class="reference internal" href="_enum_mathtitle_label.html#test-exc-label-math"><span>some Test <span class="math notranslate nohighlight">\(\mathbb{R}\)</span> text 1 test</span></a>.</p>
+<p>This reference includes math <a class="reference internal" href="_enum_mathtitle_label.html#test-exc-label-math"><span class="std std-numref">some 1 text test</span></a>.</p>


### PR DESCRIPTION
This PR allows `{number}` and `{name}` to work if referenced in the same role while `%s` only works if referenced by itself. This seems to be the behavior of the general `numref` role. For instance, `{number} {name} %s` will display number and name while "%s" won't work. The same is true for `{number} %s` and `{name} %s`. However, if "%s" is introduced by itself, it will display the number of the exercise directive.